### PR TITLE
Allow for overriding the CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@
 SHELL   = /bin/sh
 CC      = gcc
 
-CFLAGS  = -pedantic -Wall -O3
-LFLAGS = -lm
+CFLAGS  += -pedantic -Wall -O3
+LFLAGS = -lm $(LDFLAGS)
 
 TARGET  = prodigal
 SOURCES = $(shell echo *.c)


### PR DESCRIPTION
This enable Debian to inject code hardening flags[0] to the compiler. Original patch is by Olivier Sallou osallou@debian.org [1]

[0] https://wiki.debian.org/Hardening
[1] http://anonscm.debian.org/viewvc/debian-med/trunk/packages/prodigal/trunk/debian/patches/hardening.patch?revision=18039&view=markup
