### PR TITLE
Revert "Added target to Makefile to build static executable"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,21 +24,17 @@ CC      = gcc
 CFLAGS  += -pedantic -Wall -O3
 LFLAGS = -lm $(LDFLAGS)
 
-TARGET  = prodigal 
-STARGET = prodigal.static
+TARGET  = prodigal
 SOURCES = $(shell echo *.c)
 HEADERS = $(shell echo *.h)
 OBJECTS = $(SOURCES:.c=.o)
 
 INSTALLDIR  = /usr/local/bin
 
-all: $(TARGET)  $(STARGET)
+all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LFLAGS)
-
-$(STARGET): $(OBJECTS)
-	$(CC) -static $(CFLAGS) -o $@ $^ $(LFLAGS)
 
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
Reverts hyattpd/Prodigal#16

After finding out Mac doesn't support static linking, reverting this change.
