### PR TITLE
Support consuming compressed files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@
 SHELL   = /bin/sh
 CC      = gcc
 
-CFLAGS  += -pedantic -Wall -O3
-LFLAGS = -lm $(LDFLAGS)
+CFLAGS  += -pedantic -Wall -O3 -DSUPPORT_GZIP_COMPRESSED
+LFLAGS = -lm $(LDFLAGS) -lz
 
 TARGET  = prodigal
 ZTARGET  = zprodigal
@@ -38,14 +38,8 @@ all: $(TARGET)
 $(TARGET): $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LFLAGS)
 
-$(ZTARGET): $(ZOBJECTS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LFLAGS) -lz -DSUPPORT_GZIP_COMPRESSED
-
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c -o $@ $<
-
-%.oz: %.c $(HEADERS)
-	$(CC) $(CFLAGS) -c -o $@ $<  -DSUPPORT_GZIP_COMPRESSED
 
 install: $(TARGET)
 	install -d -m 0755 $(INSTALLDIR)

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,11 @@ CFLAGS  += -pedantic -Wall -O3
 LFLAGS = -lm $(LDFLAGS)
 
 TARGET  = prodigal
+ZTARGET  = zprodigal
 SOURCES = $(shell echo *.c)
 HEADERS = $(shell echo *.h)
 OBJECTS = $(SOURCES:.c=.o)
+ZOBJECTS = $(SOURCES:.c=.oz)
 
 INSTALLDIR  = /usr/local/bin
 
@@ -36,8 +38,14 @@ all: $(TARGET)
 $(TARGET): $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LFLAGS)
 
+$(ZTARGET): $(ZOBJECTS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LFLAGS) -lz -DSUPPORT_GZIP_COMPRESSED
+
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.oz: %.c $(HEADERS)
+	$(CC) $(CFLAGS) -c -o $@ $<  -DSUPPORT_GZIP_COMPRESSED
 
 install: $(TARGET)
 	install -d -m 0755 $(INSTALLDIR)
@@ -47,7 +55,7 @@ uninstall:
 	-rm $(INSTALLDIR)/$(TARGET)
 
 clean:
-	-rm -f $(OBJECTS)
+	-rm -f $(OBJECTS) $(ZOBJECTS)
  
 distclean: clean
 	-rm -f $(TARGET)

--- a/fptr.h
+++ b/fptr.h
@@ -1,0 +1,17 @@
+#ifndef SGC_H__
+#define SGC_H__
+#ifdef SUPPORT_GZIP_COMPRESSED
+#include "zlib.h"
+#define fptr gzFile
+#define INPUT_OPEN gzopen
+#define INPUT_SEEK gzseek
+#define INPUT_CLOSE gzclose
+#define INPUT_GETS(str, n, stream) gzgets(stream, str, n)
+#else
+#define fptr FILE *
+#define INPUT_OPEN fopen
+#define INPUT_SEEK fseek
+#define INPUT_CLOSE fclose
+#define INPUT_GETS(str, n, stream) fgets(str, n, stream)
+#endif
+#endif

--- a/main.c
+++ b/main.c
@@ -25,12 +25,15 @@
 #include "node.h"
 #include "dprog.h"
 #include "gene.h"
+#include "fptr.h"
+
 
 #define VERSION "2.6.3"
 #define DATE "February, 2016"
 
 #define MIN_SINGLE_GENOME 20000
 #define IDEAL_SINGLE_GENOME 100000
+
 
 void version();
 void usage(char *);
@@ -47,7 +50,8 @@ int main(int argc, char *argv[]) {
   char *train_file, *start_file, *trans_file, *nuc_file; 
   char *input_file, *output_file, input_copy[MAX_LINE];
   char cur_header[MAX_LINE], new_header[MAX_LINE], short_header[MAX_LINE];
-  FILE *input_ptr, *output_ptr, *start_ptr, *trans_ptr, *nuc_ptr;
+  FILE *output_ptr, *start_ptr, *trans_ptr, *nuc_ptr;
+  fptr input_ptr = NULL;
   struct stat fbuf;
   pid_t pid;
   struct _node *nodes;
@@ -89,7 +93,7 @@ int main(int argc, char *argv[]) {
   start_file = NULL; trans_file = NULL; nuc_file = NULL;
   start_ptr = stdout; trans_ptr = stdout; nuc_ptr = stdout;
   input_file = NULL; output_file = NULL; piped = 0;
-  input_ptr = stdin; output_ptr = stdout; max_slen = 0;
+  output_ptr = stdout; max_slen = 0;
   output = 0; closed = 0; do_mask = 0; force_nonsd = 0;
 
   /* Filename for input copy if needed */
@@ -249,7 +253,14 @@ int main(int argc, char *argv[]) {
 
   /* Check i/o files (if specified) and prepare them for reading/writing */
   if(input_file != NULL) {
-    input_ptr = fopen(input_file, "r");
+    input_ptr = INPUT_OPEN(input_file, "r");
+    if(input_ptr == NULL) {
+      fprintf(stderr, "\nError: can't open input file %s.\n\n", input_file);
+      exit(5);
+    }
+  }
+  if(input_ptr == NULL) {
+    input_ptr = INPUT_OPEN("/dev/stdin", "r");
     if(input_ptr == NULL) {
       fprintf(stderr, "\nError: can't open input file %s.\n\n", input_file);
       exit(5);
@@ -423,7 +434,7 @@ int main(int argc, char *argv[]) {
 
     /* Rewind input file */    
     if(quiet == 0) fprintf(stderr, "-------------------------------------\n");
-    if(fseek(input_ptr, 0, SEEK_SET) == -1) {
+    if(INPUT_SEEK(input_ptr, 0, SEEK_SET) == -1) {
       fprintf(stderr, "\nError: could not rewind input file.\n"); 
       exit(13);
     }
@@ -600,15 +611,15 @@ int main(int argc, char *argv[]) {
   }
 
   /* Free all memory */
-  if(seq != NULL) free(seq);
-  if(rseq != NULL) free(rseq);
-  if(useq != NULL) free(useq);
-  if(nodes != NULL) free(nodes);
-  if(genes != NULL) free(genes);
-  for(i = 0; i < NUM_META; i++) if(meta[i].tinf != NULL) free(meta[i].tinf);
+  free(seq);
+  free(rseq);
+  free(useq);
+  free(nodes);
+  free(genes);
+  for(i = 0; i < NUM_META; i++) free(meta[i].tinf);
 
   /* Close all the filehandles and exit */
-  if(input_ptr != stdin) fclose(input_ptr);
+  INPUT_CLOSE(input_ptr);
   if(output_ptr != stdout) fclose(output_ptr);
   if(start_ptr != stdout) fclose(start_ptr);
   if(trans_ptr != stdout) fclose(trans_ptr);

--- a/sequence.h
+++ b/sequence.h
@@ -27,6 +27,7 @@
 #include <math.h>
 #include "bitmap.h"
 #include "training.h"
+#include "fptr.h"
 
 #define MAX_SEQ 32000000
 #define MAX_LINE 10000
@@ -44,9 +45,9 @@ typedef struct _mask {
   int end;
 } mask;
 
-int read_seq_training(FILE *, unsigned char *, unsigned char *, double *, int,
+int read_seq_training(fptr, unsigned char *, unsigned char *, double *, int,
                       mask *, int *);
-int next_seq_multi(FILE *, unsigned char *, unsigned char *, int *, double *,
+int next_seq_multi(fptr, unsigned char *, unsigned char *, int *, double *,
                    int, mask *, int *, char *, char *);
 void rcom_seq(unsigned char *, unsigned char *, unsigned char *, int);
 

--- a/training.h
+++ b/training.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+
 struct _training {
   double gc;                    /* GC Content */
   int trans_table;              /* 11 = Standard Microbial, NCBI Trans Table to


### PR DESCRIPTION
Transparently processes both compressed and uncompressed input fasta with zprodigal, while prodigal remains unchanged.

It was convenient for our purposes to avoid a second file on disk for the workflow, and I wanted to pass the changes along.