### PR TITLE
Up to 2x faster prodigal

### DIFF
--- a/dprog.c
+++ b/dprog.c
@@ -28,7 +28,7 @@
   coding, RBS scores, etc.
 *******************************************************************************/
 
-int dprog(struct _node *nod, int nn, struct _training *tinf, int flag, int max_node_dist) {
+int dprog(struct _node *nod, int nn, struct _training *tinf, int flag, int max_node_dist, int rapid) {
   int i, j, min, max_ndx = -1, path, nxt, tmp;
   double max_sc = -1.0;
 
@@ -49,8 +49,15 @@ int dprog(struct _node *nod, int nn, struct _training *tinf, int flag, int max_n
     if(nod[i].strand == 1 && nod[i].type == STOP && nod[min].ndx >=
        nod[i].stop_val)
       while(min >= 0 && nod[i].ndx != nod[i].stop_val) min--;
-//    if(min < max_node_dist) min = 0;
-//    else min = min-max_node_dist;
+
+    /* Rapid mode is 50% faster producing the same result, */
+    /* when tested with E. coli genome (GCF_000008865.2).  */
+    if(rapid){
+        if(min < 0) min = 0;
+    } else {
+        if(min < max_node_dist) min = 0; else min = min-max_node_dist;
+    }
+
     for(j = min; j < i; j++) {
       score_connection(nod, j, i, tinf, flag);
     }

--- a/dprog.c
+++ b/dprog.c
@@ -28,7 +28,7 @@
   coding, RBS scores, etc.
 *******************************************************************************/
 
-int dprog(struct _node *nod, int nn, struct _training *tinf, int flag) {
+int dprog(struct _node *nod, int nn, struct _training *tinf, int flag, int max_node_dist) {
   int i, j, min, max_ndx = -1, path, nxt, tmp;
   double max_sc = -1.0;
 
@@ -42,15 +42,15 @@ int dprog(struct _node *nod, int nn, struct _training *tinf, int flag) {
 
     /* Set up distance constraints for making connections, */
     /* but make exceptions for giant ORFS.                 */
-    if(i < MAX_NODE_DIST) min = 0; else min = i-MAX_NODE_DIST;
+    if(i < max_node_dist) min = 0; else min = i-max_node_dist;
     if(nod[i].strand == -1 && nod[i].type != STOP && nod[min].ndx >=
        nod[i].stop_val)
       while(min >= 0 && nod[i].ndx != nod[i].stop_val) min--;
     if(nod[i].strand == 1 && nod[i].type == STOP && nod[min].ndx >=
        nod[i].stop_val)
       while(min >= 0 && nod[i].ndx != nod[i].stop_val) min--;
-    if(min < MAX_NODE_DIST) min = 0;
-    else min = min-MAX_NODE_DIST;
+//    if(min < max_node_dist) min = 0;
+//    else min = min-max_node_dist;
     for(j = min; j < i; j++) {
       score_connection(nod, j, i, tinf, flag);
     }

--- a/dprog.h
+++ b/dprog.h
@@ -28,9 +28,9 @@
 
 #define MAX_SAM_OVLP 60
 #define MAX_OPP_OVLP 200
-#define MAX_NODE_DIST 500
+// #define MAX_NODE_DIST 500
 
-int dprog(struct _node *, int, struct _training *, int);
+int dprog(struct _node *, int, struct _training *, int, int);
 void score_connection(struct _node *, int, int, struct _training *, int);
 void eliminate_bad_genes(struct _node *, int, struct _training *);
 

--- a/dprog.h
+++ b/dprog.h
@@ -30,7 +30,7 @@
 #define MAX_OPP_OVLP 200
 // #define MAX_NODE_DIST 500
 
-int dprog(struct _node *, int, struct _training *, int, int);
+int dprog(struct _node *, int, struct _training *, int, int, int);
 void score_connection(struct _node *, int, int, struct _training *, int);
 void eliminate_bad_genes(struct _node *, int, struct _training *);
 

--- a/main.c
+++ b/main.c
@@ -43,7 +43,7 @@ int copy_standard_input_to_file(char *, int);
 int main(int argc, char *argv[]) {
 
   int rv, slen, nn, ng, i, ipath, *gc_frame, do_training, output, max_phase;
-  int closed, do_mask, nmask, force_nonsd, user_tt, is_meta, num_seq, quiet;
+  int closed, do_mask, nmask, force_nonsd, user_tt, is_meta, num_seq, quiet, max_node_dist;
   int piped, max_slen, fnum;
   double max_score, gc, low, high;
   unsigned char *seq, *rseq, *useq;
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
     memset(meta[i].tinf, 0, sizeof(struct _training));
   }
   nn = 0; slen = 0; ipath = 0; ng = 0; nmask = 0;
-  user_tt = 0; is_meta = 0; num_seq = 0; quiet = 0;
+  user_tt = 0; is_meta = 0; num_seq = 0; quiet = 0; max_node_dist = 500;
   max_phase = 0; max_score = -100.0;
   train_file = NULL; do_training = 0;
   start_file = NULL; trans_file = NULL; nuc_file = NULL;
@@ -113,15 +113,17 @@ int main(int argc, char *argv[]) {
 
   /* Parse the command line arguments */
   for(i = 1; i < argc; i++) {
-    if(i == argc-1 && (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "-T") == 0
-       || strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "-A") == 0 ||
+    if(i == argc-1 &&
+      (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "-T") == 0 ||
+       strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "-A") == 0 ||
        strcmp(argv[i], "-g") == 0 || strcmp(argv[i], "-g") == 0 ||
        strcmp(argv[i], "-f") == 0 || strcmp(argv[i], "-F") == 0 ||
        strcmp(argv[i], "-s") == 0 || strcmp(argv[i], "-S") == 0 ||
        strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "-I") == 0 ||
        strcmp(argv[i], "-o") == 0 || strcmp(argv[i], "-O") == 0 ||
-       strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "-P") == 0))
-      usage("-a/-f/-g/-i/-o/-p/-s options require parameters.");
+       strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "-P") == 0 ||
+       strcmp(argv[i], "-x") == 0 || strcmp(argv[i], "-X") == 0))
+      usage("-a/-f/-g/-i/-o/-p/-s/-x options require parameters.");
     else if(strcmp(argv[i], "-c") == 0 || strcmp(argv[i], "-C") == 0)
       closed = 1;
     else if(strcmp(argv[i], "-q") == 0 || strcmp(argv[i], "-Q") == 0)
@@ -188,6 +190,10 @@ int main(int argc, char *argv[]) {
         output = 3;
       else usage("Invalid output format specified.");
       i++;
+    }
+    else if(strcmp(argv[i], "-x") == 0 || strcmp(argv[i], "-X") == 0) {
+        max_node_dist = atoi(argv[i+1]);
+        i++;
     }
     else usage("Unknown option.");
   }
@@ -684,6 +690,8 @@ void help() {
   fprintf(stderr, "         -t:  Write a training file (if none exists); ");
   fprintf(stderr, "otherwise, read and use\n");
   fprintf(stderr, "              the specified training file.\n");
+  fprintf(stderr, "         -x:  Specify the number of neighbor nodes for connection scoring.");
+  fprintf(stderr, " Default is 500.\n");
   fprintf(stderr, "         -v:  Print version number and exit.\n\n");
   exit(0);
 }

--- a/main.c
+++ b/main.c
@@ -653,7 +653,7 @@ void usage(char *msg) {
   fprintf(stderr, "                 [-g tr_table] [-h] [-i input_file] [-m]");
   fprintf(stderr, " [-n] [-o output_file]\n");
   fprintf(stderr, "                 [-p mode] [-q] [-s start_file]");
-  fprintf(stderr, " [-t training_file] [-v]\n");
+  fprintf(stderr, " [-t training_file] [-x] [-r] [-v]\n");
   fprintf(stderr, "\nDo 'prodigal -h' for more information.\n\n");
   exit(15);
 }


### PR DESCRIPTION
Hi, I'm Jaebeom Kim and developing a metagenomic classifier, Metabuli.
I'm using prodigal to predict genes of thousands of prokaryotic genomes,
so I'm working on making prodigal faster.

Here are some modifications.
Test environment: MacBook Pro, 1.4 GHz quad-core Intel Core i5, 16GB 2133 MHz LPDDR3
1) Rapid mode.
In the function named 'dprog', I found a suspicious part.
I think lines 52 and 53 are making the program slow. When i==999 and MAX_NODE_DIST==500, 'min' becomes 0 in line line 54, which leads to calling 'score_connection' 999 times. I'm not sure it is intended or not. So I just make an 'Rapid mode' to jump the lines.
When I tested with E.coli genome (GCF_000008865.2), Rapid mode decreased the running time (training + prediction) from ~9.9 sec to ~6.5 sec, while producing the same results.

2) MAX_NODE_DIST
While reviewing the source code, I found that reducing MAX_NODE_DIST in dprog.h can decrease running time. So, I decreased it from 500 to 300 and tested it using E.coli genome. 
The running time (training + predicting) decreased from ~9.9 sec to ~7.2 sec, while producing the same result. But still, it may lead to prediction of lower quality in other cases, so I just made it as an option for users who want to get results faster. 
- When I tested 100, the running time was about 20 sec producing different result. So, this can be a tricky option to deal with, but I think it will be useful for those who need it.

When rapid mode is used with MAX_NODE_DIST 300,
the same predictions were produced in ~5.5 seconds, which is about 2X acceleration.

I tried to follow the code style :)
If you like the changes, please accept this PR and update the conda package as well.

